### PR TITLE
Fix Blade Whisperer grafting broken bladelink comps onto unique weapons (#16)

### DIFF
--- a/Source/Patches/BladeWhispererPatches.cs
+++ b/Source/Patches/BladeWhispererPatches.cs
@@ -23,7 +23,10 @@ public static class BladeWhisperer_Notify_Equipped_Patch
             return;
         }
 
-        if (__instance.def.HasComp(typeof(CompBladelinkWeapon)) || __instance.def.HasComp(typeof(CompBiocodable)) || __instance.TryGetComp<CompBladelinkWeapon>() != null)
+        // CompUniqueWeapon is excluded because it scribes a "traits" node of its own: a
+        // coexisting bladelink comp would save a second sibling node with the same name,
+        // and both comps would read back the first one (issue #16).
+        if (__instance.def.HasComp(typeof(CompBladelinkWeapon)) || __instance.def.HasComp(typeof(CompBiocodable)) || __instance.def.HasComp(typeof(CompUniqueWeapon)) || __instance.TryGetComp<CompBladelinkWeapon>() != null)
         {
             return;
         }
@@ -32,6 +35,11 @@ public static class BladeWhisperer_Notify_Equipped_Patch
         try
         {
             thingComp.parent = __instance;
+            // Runtime-created comps never get props assigned (InitializeComps only does that
+            // for def-borne comps), and vanilla CompBiocodable.Notify_Equipped dereferences
+            // Props on every equip - a props-less comp NREs and makes the weapon
+            // permanently unequippable (issue #16). Mirror the vanilla persona weapon defs.
+            thingComp.props = new CompProperties_BladelinkWeapon { biocodeOnEquip = true };
             InitializeSingleTrait(thingComp);
             __instance.AllComps.Add(thingComp);
 
@@ -131,17 +139,24 @@ public static class BladeWhisperer_ExposeData_Patch
 
     static void AddBladelinkComp(ThingWithComps thingWithComps)
     {
-        if (thingWithComps.def.HasComp(typeof(CompBladelinkWeapon)) || thingWithComps.def.HasComp(typeof(CompBiocodable)) || thingWithComps.TryGetComp<CompBladelinkWeapon>() != null)
+        if (thingWithComps.def.HasComp(typeof(CompBladelinkWeapon)) || thingWithComps.def.HasComp(typeof(CompBiocodable)) || thingWithComps.def.HasComp(typeof(CompUniqueWeapon)) || thingWithComps.TryGetComp<CompBladelinkWeapon>() != null)
         {
             return;
         }
 
-        if (Scribe.EnterNode("traits"))
+        // A saved whispered bond is always biocoded (CodeFor runs on equip, and the comp is
+        // removed on unequip), and Scribe_Values only writes "biocoded" when it is true - so
+        // this node identifies exactly our own saved comp. The previous check,
+        // EnterNode("traits"), false-positived on any other comp that scribes a list named
+        // "traits" - e.g. Odyssey's CompUniqueWeapon - grafting a broken bladelink comp onto
+        // every unique weapon on load (issue #16).
+        if (Scribe.EnterNode("biocoded"))
         {
             try
             {
                 CompBladelinkWeapon thingComp = new CompBladelinkWeapon();
                 thingComp.parent = thingWithComps;
+                thingComp.props = new CompProperties_BladelinkWeapon { biocodeOnEquip = true };
 
                 thingWithComps.AllComps.Add(thingComp);
             }


### PR DESCRIPTION
Fixes #16.

## What was happening

`BladeWhisperer_ExposeData_Patch.AddBladelinkComp` keys its save-restore on `Scribe.EnterNode("traits")`. Odyssey's `CompUniqueWeapon` scribes its trait list under that exact node name, so on load, every unique weapon (vanilla melee-unique mods, e.g. Unique Melee Weapons; Odyssey's own ranged uniques are only spared because their defs carry `CompProperties_Biocodable`) matched the check and got a `CompBladelinkWeapon` grafted on — with no Blade Whisperer involvement at all.

Worse, comps created with `new` never get `props` assigned (only `InitializeComps` does that for def-borne comps), and vanilla `CompBiocodable.Notify_Equipped` dereferences `Props` unconditionally:

```csharp
if (Biocodable && Props.biocodeOnEquip) // NRE when props == null
```

so any equip that finds one of these grafted comps throws `NullReferenceException` inside `JobDriver_Equip`. In the intended Blade Whisperer flow this isn't a problem, because the `Notify_Unequipped` postfix removes the comp (for pawns with the trait) before the next equip. The falsely-grafted comps from the load restore on unique melee weapons have no such escape: they sit on weapons whose equippers don't have the trait, so a red error fires on every equip attempt:

```
System.NullReferenceException at RimWorld.CompBiocodable.Notify_Equipped (Verse.Pawn pawn) [0x0000e]
  at RimWorld.CompBladelinkWeapon.Notify_Equipped (Verse.Pawn pawn) [0x0000d]
  at Verse.ThingWithComps.Notify_Equipped (Verse.Pawn pawn) [0x00025]
```

## The fix (all in `BladeWhispererPatches.cs`)

1. **Assign `CompProperties_BladelinkWeapon { biocodeOnEquip = true }` to both runtime grafts** (equip postfix and load restore), mirroring the vanilla persona weapon defs.
2. **Restore heuristic: `EnterNode("traits")` → `EnterNode("biocoded")`.** A saved whispered bond is always biocoded (`CodeFor` runs on equip and the comp is removed on unequip), and `Scribe_Values` only writes `biocoded` when true — so the node identifies exactly this mod's own saved comp and cannot false-positive on other comps' trait lists.
3. **Exclude defs with `CompUniqueWeapon` from Blade Whisperer.** Both `CompUniqueWeapon` and `CompBladelinkWeapon` scribe a node named `traits`, so if they coexist on one thing the save gets duplicate sibling nodes and both comps read back the first one. Unique weapons therefore can't safely host a whispered bond (consistent with the existing exclusion of biocodable weapons).

Existing saves self-heal: the stray graft was never part of the def, and with the corrected heuristic it simply isn't re-added on the next load; the leftover scribe fields are ignored.

Source-only change — While I've tested the build locally, I've left rebuilding the shipped `1.6/Assemblies/MorePersonaTraits.dll` to you since the repo tracks release binaries. Compile-checked against `Krafs.Rimworld.Ref 1.6.4507-beta`; `CompUniqueWeapon` references are safe for the older game versions because this source only builds the 1.6 assembly.

## Tested in-game

RimWorld 1.6.4871, alongside Unique Melee Weapons (a `CompUniqueWeapon`-based mod affected by #16):

- **Current MPT (reproduces #16):** every unique melee weapon gains a bladelink comp on load, shows "Not yet bonded", and NREs on any equip attempt. Additionally, a UMW weapon genuinely whisper-bonded and saved while equipped reloads with its bladelink trait list overwritten by the unique weapon's traits — both comps read back the first `traits` node. Screenshot: <img width="1424" height="1132" alt="image" src="https://github.com/user-attachments/assets/0fcb797e-1eff-4fda-aa98-0a865b149378" />
- **This PR:** unique weapons load with no bladelink comp and equip normally. The Blade Whisperer flow works end to end on ordinary melee weapons — bond on equip, comp removal on unequip/drop, clean re-equip, and a bond saved while equipped restores correctly (pawn and trait intact). A Blade Whisperer equipping a unique weapon now safely gets no bond.

## Possible follow-up: drop the heuristic entirely

Comps scribe their fields flat into the parent thing's node, which is why detection-by-node-name is fragile at all. Since Blade Whisperer constructs the comp itself, it could instead graft a subclass (the csproj's commented-out `MPT_CompBladelinkWeapon.cs` suggests this was once started) whose `PostExposeData` wraps the base call in `Scribe.EnterNode("MPT_bladelink") ... ExitNode`. That namespaces every bladelink field into one sub-node, so:

- the restore check becomes exact — `EnterNode("MPT_bladelink")` can only ever match this mod's own saved comp, with no possibility of colliding with another comp's field names, and
- the `traits`-node collision with `CompUniqueWeapon` disappears at the save layer — which would also make the def-level exclusion in this PR optional rather than required. On closer inspection the remaining runtime seams look benign: each comp only ever reads its own trait list (the vanilla readers of `equippedStatOffsets`/`killThought` consult the bladelink comp's list, never the unique comp's), `WeaponTraitDef.abilityProps` is consumed solely by `CompUniqueWeapon` so nothing competes for the `CompEquippableAbilityReloadable` slot, and the `TransformLabel` chain composes (unique name plus biocoded decoration). So a namespaced comp could plausibly let Blade Whisperer bond unique weapons for real, if that's a combination you want to support — though that pairing has only been lightly reasoned through, not soak-tested, so keeping the exclusion until it's deliberately supported is equally defensible.

